### PR TITLE
Feature/dschrader/123 add first name to comment element

### DIFF
--- a/src/features/comments/api/createComment.ts
+++ b/src/features/comments/api/createComment.ts
@@ -10,6 +10,7 @@ export type CreateCommentDTO = {
   data: {
     body: string;
     discussionId: string;
+    authorFirstName: string | undefined;
   };
 };
 

--- a/src/features/comments/components/CommentsList.tsx
+++ b/src/features/comments/components/CommentsList.tsx
@@ -52,7 +52,7 @@ export const CommentsList = ({ discussionId }: CommentsListProps) => {
               <DeleteComment discussionId={discussionId} id={comment.id} />
             </div>
           </Authorization>
-
+          <h2>{comment?.authorFirstName}</h2>
           <MDPreview value={comment.body} />
         </li>
       ))}

--- a/src/features/comments/components/CreateComment.tsx
+++ b/src/features/comments/components/CreateComment.tsx
@@ -3,6 +3,7 @@ import * as z from 'zod';
 
 import { Button } from '@/components/Elements';
 import { Form, FormDrawer, TextAreaField } from '@/components/Form';
+import { useAuth } from '@/lib/auth';
 
 import { CreateCommentDTO, useCreateComment } from '../api/createComment';
 
@@ -16,6 +17,7 @@ type CreateCommentProps = {
 
 export const CreateComment = ({ discussionId }: CreateCommentProps) => {
   const createCommentMutation = useCreateComment({ discussionId });
+  const { user } = useAuth();
   return (
     <>
       <FormDrawer
@@ -45,6 +47,7 @@ export const CreateComment = ({ discussionId }: CreateCommentProps) => {
               data: {
                 body: values.body,
                 discussionId,
+                authorFirstName: user?.firstName,
               },
             });
           }}

--- a/src/features/comments/types/index.ts
+++ b/src/features/comments/types/index.ts
@@ -4,4 +4,5 @@ export type Comment = {
   body: string;
   authorId: string;
   discussionId: string;
+  authorFirstName: string;
 } & BaseEntity;

--- a/src/features/discussions/api/createDiscussion.ts
+++ b/src/features/discussions/api/createDiscussion.ts
@@ -10,6 +10,7 @@ export type CreateDiscussionDTO = {
   data: {
     title: string;
     body: string;
+    authorFirstName: string | undefined;
   };
 };
 

--- a/src/test/server/db.ts
+++ b/src/test/server/db.ts
@@ -31,6 +31,7 @@ const models = {
     authorId: String,
     discussionId: String,
     createdAt: Number,
+    authorFirstName: String,
   },
 };
 


### PR DESCRIPTION
This PR adds support for displaying the author's firstname in each of their respective comment elements. 

This change adds to the user experience as users can now see who has written each comment on a discussion, without seeing another user's user name. 

This PR adds authorFirstName as a property on the comment type, post body for the create comment API call, data model on the mock back end/DB, and pulls in author's firstname for display directly in the comment element. 